### PR TITLE
Add Flatten list without recursion alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,29 @@ nested_lists = [[1, 2], [[3, 4], [5, 6], [[7, 8], [9, 10], [[11, [12, 13]]]]]]
 flatten = lambda x: [y for l in x for y in flatten(l)] if type(x) is list else [x]
 flatten(nested_lists)
 
+==> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+
 # This line of code is from
 # https://github.com/sahands/python-by-example/blob/master/python-by-example.rst#flattening-lists
+```
+
+If we reach max recursion depth (i.e. stack overflows) when `nested_lists` is too deep, we can do this instead.
+```python
+
+def flatten2(nested_list):
+    nested_list = nested_list.copy()
+    while nested_list:
+        sublist = nested_list.pop(0)
+        if isinstance(sublist, list):
+            nested_list = sublist + nested_list
+        else:
+            yield sublist
+list(flatten2(nested_lists))  # function returns a generator
+
+==> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+
+# This code is adapted from
+# https://gist.github.com/Wilfred/7889868
 ```
 
 ### 2.5 List vs generator

--- a/cool-python-tips.ipynb
+++ b/cool-python-tips.ipynb
@@ -506,6 +506,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If we reach max recursion depth (i.e. stack overflows) when `nested_lists` is too deep, we can do this instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]"
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def flatten2(nested_list):\n",
+    "    nested_list = nested_list.copy()\n",
+    "    while nested_list:\n",
+    "        sublist = nested_list.pop(0)\n",
+    "        if isinstance(sublist, list):\n",
+    "            nested_list = sublist + nested_list\n",
+    "        else:\n",
+    "            yield sublist\n",
+    "list(flatten2(nested_lists))  # function returns a generator\n",
+    "\n",
+    "# This code is adapted from\n",
+    "# https://gist.github.com/Wilfred/7889868"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2.5 List vs generator\n",
     "To illustrate the difference between a list and a generator, let's look at an example of creating n-grams out of a list of tokens.\n",
     "\n",


### PR DESCRIPTION
Hi. Thanks a lot for the cool tips!

In the List Flattening section, I thought it might be worthwhile to include an option for the (quite rare) cases when we run into recursion error if the list is too deeply nested.

Hope this fits in well with the repo. Thanks for checking this out.